### PR TITLE
Simplify installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,7 @@ You need a Linux server with `git` and `sshd` installed.
 
 ## Installing
 
-On your server, run:
-
-    $ curl https://raw.github.com/progrium/gitreceive/master/installer | bash
-
-This will install `gitreceive` into `/usr/local/bin`. Alternatively,
-clone this repo and put `gitreceive` wherever you want.
+On your server, download https://raw.github.com/progrium/gitreceive/master/gitreceive to a location on your $PATH and make it executable.
 
 ## Using gitreceive
 

--- a/installer
+++ b/installer
@@ -1,4 +1,0 @@
-# this is to be used with:
-# curl https://raw.github.com/progrium/gitreceive/master/installer | bash
-curl --silent https://raw.github.com/progrium/gitreceive/master/gitreceive > /usr/local/bin/gitreceive
-chmod +x /usr/local/bin/gitreceive


### PR DESCRIPTION
Since this project consists of one shell script and the installer script simply downloads this shell script and makes it executable, asking people to run bash directly from curl seems like overkill. Let's just have users download the script to a location of their choosing.
