### PR TITLE
Use git-shell in 'gitreceive run'

### DIFF
--- a/gitreceive
+++ b/gitreceive
@@ -56,7 +56,7 @@ EOF
 cat | $SELF hook
 EOF
     chmod +x $PRERECEIVE_HOOK
-    eval $SSH_ORIGINAL_COMMAND
+    eval "git-shell -c \"$SSH_ORIGINAL_COMMAND\""
     ;;
 
   hook)


### PR DESCRIPTION
gitreceive currently allows users to execute arbitrary commands on the system
eg: ssh git@whatever /bin/bash

This patch uses git-shell to evaluate the command sent by remote users,
restricting command execution to git-related programs.
