### PR TITLE
Now showing username argument in gitreceive upload-key command example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ The repo contents are streamed into `STDIN` as an uncompressed archive (tar file
 
 We just pipe it into the `gitreceive upload-key` command via SSH:
 
-    $ cat ~/.ssh/id_rsa.pub | ssh you@yourserver.com "sudo gitreceive upload-key progrium"
+    $ cat ~/.ssh/id_rsa.pub | ssh you@yourserver.com "sudo gitreceive upload-key <username>"
 
-The username argument is just an arbitrary name associated with the key, mostly
+The `username` argument is just an arbitrary name associated with the key, mostly
 for use in your system for auth, etc.
 
 #### Add a remote to a local repository


### PR DESCRIPTION
It took me awhile to notice that `progrium` was actually the username argument.
