### PR TITLE
Fix arbitrary execution of code by untrusted user input.

### DIFF
--- a/gitreceive
+++ b/gitreceive
@@ -44,7 +44,7 @@ EOF
     export RECEIVE_USER=$2
     export RECEIVE_FINGERPRINT=$3
     # ssh provides the original requested command in $SSH_ORIGINAL_COMMAND
-    eval $(echo $SSH_ORIGINAL_COMMAND | awk '{print "export RECEIVE_REPO="$2}')
+    export RECEIVE_REPO="$(echo $SSH_ORIGINAL_COMMAND | awk '{print $2}')"
     REPO_PATH="$GITHOME/$RECEIVE_REPO"
     if [ ! -d $REPO_PATH ]; then
       mkdir -p $REPO_PATH
@@ -58,7 +58,7 @@ EOF
 cat | $SELF hook
 EOF
     chmod +x $PRERECEIVE_HOOK
-    eval "git-shell -c \"$SSH_ORIGINAL_COMMAND\""
+    git-shell -c "$SSH_ORIGINAL_COMMAND"
     ;;
 
   hook)


### PR DESCRIPTION
SSH_ORIGINAL_COMMAND was used in an eval() without check: in a normal
git push this is not a problem but under the hood this  is only
an ssh command so a malicious user could do something like the following

```
$ ssh vagrant -C 'bar "foo;rm -vfr /tmp/"'
/usr/local/bin/gitreceive: eval: line 45: unexpected EOF while looking for matching `"'
/usr/local/bin/gitreceive: eval: line 46: syntax error: unexpected end of file
/usr/local/bin/gitreceive: line 54: /home/git//hooks/pre-receive: No such file or directory
chmod: cannot access `/home/git//hooks/pre-receive': No such file or directory
fatal: unrecognized command 'bar foo'
rm: cannot remove `/tmp': Permission denied
```

If people have `gitreceive` live with untrusted users I advice them to update as soon as possible.

I have not extensively tested this patch, comments are welcome.
