### PR TITLE
Fix issue with single quotes surrounding repo name

### DIFF
--- a/gitreceive
+++ b/gitreceive
@@ -44,7 +44,7 @@ EOF
     export RECEIVE_USER=$2
     export RECEIVE_FINGERPRINT=$3
     # ssh provides the original requested command in $SSH_ORIGINAL_COMMAND
-    export RECEIVE_REPO="$(echo $SSH_ORIGINAL_COMMAND | awk '{print $2}' | perl -pe 's/(?<!\\)'\''//g' | sed 's/\\//g')"
+    export RECEIVE_REPO="$(echo $SSH_ORIGINAL_COMMAND | awk '{print $2}' | perl -pe 's/(?<!\\)'\''//g' | sed 's/\\'\''/'\''/g')"
     REPO_PATH="$GITHOME/$RECEIVE_REPO"
     if [ ! -d $REPO_PATH ]; then
       mkdir -p $REPO_PATH


### PR DESCRIPTION
The changes in fe6f338 lead to an issue where the repo name would end up being surrounded by single quotes (e.g. `'reponame.git'`) and thus causing errors like this when pushing:

```
$ git push remote master
fatal: 'reponame.git' does not appear to be a git repository
fatal: Could not read from remote repository.
```

The cause for the issue is that – at least in my setup – `SSH_ORIGINAL_COMMAND` is set to `git-receive-pack 'reponame.git'` .

The proposed fix aims to do two things:
1. **The perl bit**: replace all single quotes that are not preceded by a backslash (`\`). The reasoning behind this is that if the actual repo name contains a single quote (e.g. `foo'bar`) the `SSH_ORIGINAL_COMMAND` looks like `git-receive-pack 'foo'\''bar'`.
2. **The sed bit**: if the actual repo name contained a single quote (e.g. `foo'bar`) the `RECEIVE_REPO` would end up as `foo\'bar`. So we unescape all escaped single quotes.

Tested successfully with the following repo names:
- `foo`
- `foo'bar`
- `foo'bar'baz`
- `foo'bar\baz`

More details in #16.

Fixes parts of the problem described in [#261](https://github.com/progrium/dokku/issues/261#issuecomment-27046939).
