### PR TITLE
fixed upload-key command when GITUSER is set

### DIFF
--- a/gitreceive
+++ b/gitreceive
@@ -34,7 +34,7 @@ EOF
     FINGERPRINT=$(ssh-keygen -lf /dev/stdin <<< $(echo $KEY) | awk '{print $2}')
     AUTHORIZED_KEYS=$GITHOME/.ssh/authorized_keys
     # When this key is used, use the ssh 'forced command' feature to have 'gitreceive run' to run instead.
-    KEY_PREFIX="command=\"$SELF run $2 $FINGERPRINT\",no-agent-forwarding,no-pty,no-user-rc,no-X11-forwarding,no-port-forwarding"
+    KEY_PREFIX="command=\"GITUSER=$GITUSER $SELF run $2 $FINGERPRINT\",no-agent-forwarding,no-pty,no-user-rc,no-X11-forwarding,no-port-forwarding"
     echo "$KEY_PREFIX $KEY" >> $AUTHORIZED_KEYS
     echo $FINGERPRINT
     ;;


### PR DESCRIPTION
When using custom user (GITUSER is set), upload-key command produces command for user 'git'.
Here is the fix.
