### PR TITLE
Add vim modeline magic

### DIFF
--- a/gitreceive
+++ b/gitreceive
@@ -175,3 +175,5 @@ main() {
 }
 
 [[ "$0" == "$BASH_SOURCE" ]] && main $@
+
+# vim: set ts=2 sw=2 et:


### PR DESCRIPTION
Automagically enforce a 2 space indentation to vim users.

Nothing fancy, just one comment line at the end of the file. The alternative is to put this line at the very top of the file, just after the shebang (i.e. on line number 2). Please tell me if you prefer the alternative more.
