### PR TITLE
Error message for repo creation when file exits

### DIFF
--- a/gitreceive
+++ b/gitreceive
@@ -81,6 +81,10 @@ parse_repo_from_ssh_command() {
 ensure_bare_repo() {
   declare repo_path="$1"
   if [ ! -d "$repo_path" ]; then
+    if [ -e "$repo_path" ]; then
+      echo 'Fatal error: invalid repository name.' > /dev/stderr
+      exit 1
+    fi
     mkdir -p "$repo_path"
     cd "$repo_path"
     git init --bare > /dev/null


### PR DESCRIPTION
When a file with the repo name exists in `$GITHOME`, exit with an error message.

This gives a proper error message (although I am open to suggestions for a better error message) when the user tries to create a repository but a file with the same name exits.

Example with the default settings (trying to create a repo named `receiver`, while a file with the same name exists in `$GITHOME`…):

Before:

```
$ git clone git@example.com:receiver
Cloning into 'receiver'...
Enter passphrase for key '<snip>': 
mkdir: cannot create directory '/home/git/receiver': File exists
fatal: Could not read from remote repository.

Please make sure you have the correct access rights and the repository exists
```

After this PR:

```
$ git clone git@git.debiantest.local:receiver
Cloning into 'receiver'...
Enter passphrase for key '<snip>': 
Fatal error: invalid repository name.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights and the repository exists.
```

Do you think the error message should be made more obvious (e.g. by inserting a newline before and after)?
