### PR TITLE
Handle creation of new repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ receiver script run any other script on the server.
 #### Handling submodules
 Submodules are not included when you do a `git push`, if you want them to be part of your workflow, have a look at [Handling Submodules](https://github.com/progrium/gitreceive/wiki/TipsAndTricks#handling-submodules).
 
+#### Handling new repository creation
+
+If you want to perform some tests when a new repository is to be made, or
+do some action afterwards, have a look at [Handling new repository creation](https://github.com/progrium/gitreceive/wiki/TipsAndTricks#handling-new-repository-creation)
+
 ## So what?
 
 You can use `gitreceive` not only to trigger code on `git push`, but to provide

--- a/gitreceive
+++ b/gitreceive
@@ -42,6 +42,26 @@ EOF
   chown "$git_user" "$receiver_path"
 }
 
+# Creates the default newrepo script. This is the script that is triggered when a new repository is to be created.
+setup_newrepo_script() {
+  declare home_dir="$1" git_user="$2"
+  local newrepo_path="$home_dir/newrepo"
+  cat > "$newrepo_path" <<EOF
+#!/bin/bash
+# This script gets called to create a new repository at \$repo_path.
+# Note: /dev/stdout is already redirected to /dev/null.
+declare repo_path="\$1" repo_name="\$2" username="\$3" fingerprint="\$4"
+
+# Here you could do some tests; exit with non-zero if anything is wrong.
+# e.g. has \$username the right to create a repository named \$repo_name?
+
+# The default is to create a bare repository (\$repo_path is absolute)
+git init --bare "\$repo_path" || exit \$?
+EOF
+  chmod +x "$newrepo_path"
+  chown "$git_user" "$newrepo_path"
+}
+
 # Generate a shorter, but still unique, version of the public key associated with the user doing `git push'
 generate_fingerprint() {
   awk '{print $2}' | base64 -d | md5sum | awk '{print $1}' | sed -e 's/../:&/2g'
@@ -78,14 +98,14 @@ parse_repo_from_ssh_command() {
 }
 
 # Create a git-enabled folder ready to receive git activity, like `git push'
-ensure_bare_repo() {
-  declare repo_path="$1"
-  if [ ! -d "$repo_path" ]; then
-    mkdir -p "$repo_path"
-    cd "$repo_path"
-    git init --bare > /dev/null
-    cd - > /dev/null
-  fi
+ensure_repo_exists() {
+  declare repo_path="$1" repo_name="$2" username="$3" fingerprint="$4" home_dir="$5"
+  # Do nothing if the repo already exists
+  [ -d "$repo_path" ] && return
+  # Call the newrepo script; abort if the return code is non-null
+  # stdout to /dev/null to avoid `protocol error: bad line length character`
+  "$home_dir/newrepo" "$repo_path" "$repo_name" "$username" "$fingerprint" > /dev/null|| exit $?
+  [ -d "$repo_path" ] || exit 1  # make sure we created a repo
 }
 
 # Create a Git pre-receive hook in a git repo that runs `gitreceive hook' when the repo receives a new git push
@@ -136,6 +156,8 @@ main() {
       setup_git_user "$GITHOME" "$GITUSER"
       setup_receiver_script "$GITHOME" "$GITUSER"
       echo "Created receiver script in $GITHOME for user '$GITUSER'."
+      setup_newrepo_script "$GITHOME" "$GITUSER"
+      echo "Created newrepo script in $GITHOME for user '$GITUSER'."
       ;;
 
     upload-key) # sudo gitreceive upload-key <username>
@@ -154,7 +176,7 @@ main() {
       export RECEIVE_FINGERPRINT="$fingerprint"
       export RECEIVE_REPO="$(echo "$SSH_ORIGINAL_COMMAND" | parse_repo_from_ssh_command)"
       local repo_path="$GITHOME/$RECEIVE_REPO"
-      ensure_bare_repo "$repo_path"
+      ensure_repo_exists "$repo_path" "$RECEIVE_REPO" "$RECEIVE_USER" "$RECEIVE_FINGERPRINT" "$GITHOME"
       ensure_prereceive_hook "$repo_path" "$GITHOME" "$SELF"
       cd "$GITHOME"
       # $SSH_ORIGINAL_COMMAND is set by `sshd'. It stores the originally intended command to be run by `git push'. In


### PR DESCRIPTION
This PR adds a new feature that allows for:
- Perform some checks before creating a new repo;
- Calling some command when a new repo is created.
# Implementation

When you `gitreceive init`, a new script named `newrepo` is created next to the `receiver` script.

When a new repository is to be created, the `newrepo` script is called instead of simply creating a new repository.

Of course, the default of the `newrepo` script is to add a new repository as always, but it also takes a few other parameters that allow to neat uses of this feature, namely the name of the repository, the username and fingerprint of the user trying to create the repository.
# Use cases
## Performing some checks before creating a new repo.

This allow to control which user/fingerprint can create which repo. Or to inforce some policy on the repo names.

As an example, the following `newrepo` script will make sure that users can only create repo starting with their usernames followed by a dash (note that only the middle part has been edited from the default `newrepo` script):

``` bash
#!/bin/bash
# This script gets called to create a new repository at $repo_path.
# Note: /dev/stdout is already redirected to /dev/null.
declare repo_path="$1" repo_name="$2" username="$3" fingerprint="$4"

# Check if $repo_name starts with $username-
if [ "${repo_name##"$username"-*}" ]; then
    echo "Error: your repos should start with '$username-'." > /dev/stderr
    exit 1
fi

# The default is to create a bare repository ($repo_path is absolute)
git init --bare "$repo_path" || exit $?
```

And here is the output when you try to git clone (the same happens if you `git remote add` and `git push` on an existing local repo):

```
$ git clone git@example.com:foobar
Cloning into 'foobar'...
Enter passphrase for key '<snip>': 
Error: your repos should start with 'alice-'.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights and the repository exists.
$ git clone git@example.com:alice-foobar
Cloning into 'alice-foobar'...
Enter passphrase for key '<snip>': 
warning: You appear to have cloned an empty repository.
Checking connectivity... done.
```
## Calling some commands when a new repo is created

Just append those commands at the end of the `newrepo` script.
# Please review

This is quite an important change, but I believe the feature could allow many use-cases, as it is quite flexible. For example, I put the `git init --bare` in the `newrepo` script to allow that to be changed if needed (however, make sure that a `repo_path` is been created).

Please note that if this PR is accepted, current gitreceive users should add a `newrepo` in their existing `$GITHOME`s, since it is only created when you `gitreceive init`. This means that some communication may be needed.

Pleade **do** review this PR. I tried to stick to the coding conventions I saw, but feel free to mention any problems (e.g. if you don't like the name of the `newrepo` script).

Final note: I've put a new link to the wiki on the README, which would have to be populated when/if this PR is merged. The content of this PR can act as a good starting point for that.
