### PR TITLE
Make it pass CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: required
+services:
+  - docker
 branches:
   only:
     - master


### PR DESCRIPTION
Travis CI failed at the current master. It's not so good that "build failing" is displayed on README...

According to [Using Docker in Builds - Travis CI](https://docs.travis-ci.com/user/docker/), I made it pass the CI.
