### PR TITLE
Prevent ref check from rejecting push

### DIFF
--- a/gitreceive
+++ b/gitreceive
@@ -111,8 +111,9 @@ trigger_receiver() {
   while read oldrev newrev refname; do
     # Only run this script for the master branch. You can remove this
     # if block if you wish to run it for others as well.
-    [[ "$refname" == "refs/heads/master" ]] && \
+    if [[ "$refname" == "refs/heads/master" ]]; then
       git archive "$newrev" | "$home_dir/receiver" "$repo" "$newrev" "$user" "$fingerprint"
+    fi
   done
 }
 


### PR DESCRIPTION
This PR prevents the push from being rejected when pushing a non-master branch.

Essentially, while the `&&` check works fine, the exit code on a non-master ref bleeds out of the loop when it's last, causing git to believe the pre-receive hook was rejected.